### PR TITLE
[QA-347] Sync submodules recursively.

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -471,7 +471,7 @@ class Git(Source, GitStepMixin):
     def _syncSubmodule(self, _=None):
         rc = RC_SUCCESS
         if self.submodules:
-            rc = yield self._dovccmd(['submodule', 'sync'])
+            rc = yield self._dovccmd(['submodule', 'sync', '--recursive'])
         return rc
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -1414,7 +1414,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
@@ -1467,7 +1467,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive', '--remote'])
@@ -2105,7 +2105,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
@@ -2157,7 +2157,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive', '--force'])
@@ -2211,7 +2211,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive',
@@ -3632,7 +3632,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='source',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='source',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
@@ -3752,7 +3752,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
 
             ExpectShell(workdir='source',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
 
             ExpectShell(workdir='source',
@@ -3811,7 +3811,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
             + 0,
             ExpectShell(workdir='source',
-                        command=['git', 'submodule', 'sync'])
+                        command=['git', 'submodule', 'sync', '--recursive'])
             + 0,
             ExpectShell(workdir='source',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])


### PR DESCRIPTION
Due to the transition from Bitbucket to Github, local checkouts in buildbot may contain submodules still pointing to Bitbucket, causing this error:
http://buildbot.slamcore.local/#/builders/8/builds/449