### PR TITLE
[QA-390] Clean stale submodules when mode=full, method=copy

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -247,6 +247,8 @@ class Git(Source, GitStepMixin):
 
         try:
             yield self.mode_incremental()
+            yield self._dovccmd(['clean', '-f', '-f', '-d', '-x'])
+            yield self._cleanSubmodule()
             cmd = remotecommand.RemoteCommand('cpdir',
                                               {'fromdir': self.srcdir,
                                                'todir': old_workdir,

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -2552,6 +2552,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='source',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
+            + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
                              'logEnviron': True, 'timeout': 1200})
             + 0,
@@ -2610,6 +2613,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='source',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
                              'logEnviron': True, 'timeout': 1200})
@@ -3637,6 +3643,12 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='source',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
             + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'foreach', '--recursive', 'git clean -f -f -d'])
+            + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
                              'logEnviron': True, 'timeout': 1200})
             + 0,
@@ -3758,7 +3770,12 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='source',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
             + 0,
-
+            ExpectShell(workdir='source',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'foreach', '--recursive', 'git clean -f -f -d'])
+            + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
                              'logEnviron': True, 'timeout': 1200})
             + 0,
@@ -3815,6 +3832,12 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='source',
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'foreach', '--recursive', 'git clean -f -f -d'])
             + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
                              'logEnviron': True, 'timeout': 1200})


### PR DESCRIPTION
This change calls `git clean` appropriately for the checked-out repository and any submodules when checking out or switching branches.

Motivation:

Consider the case where a submodule exists on branch-a but not branch-b. When using `mode=full` and `method=copy`, a `source` directory will exist and it will contain the repository at branch-a. If the next build is for branch-b, the following commands will be executed:

1. git fetch -f -t <source> branch-b --progress
2. git reset --hard <tip of branch-b> --
3. git checkout -B branch-b
4. git submodule sync
5. git submodule update --init --recursive --force --checkout

Command 2 here is expected to reset the checkout to the state <tip of branch-b>, however it will fail to remove the submodule directory and will issue a warning like:

```
warning: unable to rmdir 'path/to/submodule': Directory not empty
```

This leaves the source directory in an unexpected state and may cause errors in the build.

Implementation:

This change ensures that `git clean -f -f -d -x` is called on the checkout and that `_cleanSubmodule()` is called to clean submodules recursively also.

Note that `-f` is required twice as:
> Git will refuse to modify untracked nested git repositories (directories
> with a .git subdirectory) unless a second -f is given.

-- man git-clean

Alternatives:

Initially, the option to `git submodule deinit --all` before resetting the state was considered but this would require re-cloning submodules in the more common case where they exist on both the current and previous build.

## Testing

Aside from the updated unit tests on this branch, I've also tested this as follows:

### Setup

1. Deploy this version of buildbot
2. Build `slamcore_ros2`'s `main` branch. This doesn't have to finish,  just clone. -> http://kax-desktop.slamcore.local:8010/#/builders/78/builds/86

### Test

3. Build `slamcore_ros2`'s `release_v21.06` branch.

### Current behaviour

4. The build fails with an error like http://buildbot.slamcore.local/#/builders/61/builds/713
```
[0.177s] ERROR:colcon:colcon build: Duplicate package names not supported:
- slamcore_slam:
  - src/slamcore_ros2_wrapper/slamcore_slam
  - src/slamcore_slam
```

### Passing behaviour

5. The branch should build without issue -> http://kax-desktop.slamcore.local:8010/#/builders/78/builds/87