### PR TITLE
[QA-466] Accept non-virtual builder name in builders filter

### DIFF
--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -94,8 +94,9 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
         builder = build['builder']
         scheduler = build['properties'].get('scheduler', [None])[0]
         branch = build['properties'].get('branch', [None])[0]
+        buildername = build['properties'].get('buildername', [None])[0]
 
-        if self.builders is not None and builder['name'] not in self.builders:
+        if self.builders is not None and not (builder['name'] in self.builders or buildername in self.builders):
             return False
         if self.schedulers is not None and scheduler not in self.schedulers:
             return False


### PR DESCRIPTION
## :books: Description

Change the filtering in `is_message_needed_by_props` to accept the non-virtual builder name for a build.

## :thinking: Motivation

The [Virtual Builders pattern](https://docs.buildbot.net/latest/manual/configuration/builders.html?highlight=virtual_builder_name#virtual-builders) allows us to schedule multiple builds of the same source and builder with different properties. We use this to split the testing and packaging work over many workers.

The issue is that we would like to define a GitHubStatusPush reporter for each of these builders, however, as the `virtual_builder_name` of the builder is calculated at build time, we can't enumerate them during configuration.

## :haircut: Testing

To test I've configured the following reporters in the `master.cfg`:

```python
@renderer
def make_github_context(props):
    buildername = props.getProperty("virtual_builder_name", props["buildername"])
    return f"buildbot/{buildername}"

c['services'].append(reporters.GitHubStatusPush(
    token="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",
    baseURL="http://localhost:8080/mockgithub",
    verbose=True,
    context=make_github_context,
    builders=["sctest_target_position"]))
```

Which publishes messages like:

```
{   'context': 'buildbot/test:position/static_checks_2',
    'description': 'Build started.',
    'state': 'pending',
    'target_url': 'http://kax-desktop.slamcore.local:8010/#builders/105/builds/38'}
127.0.0.1 - - [12/Apr/2023 17:21:06] "POST /mockgithub/repos/slamcore/position/statuses/3dfc382d361b2609ca157ee9950a88c76427c1b6 HTTP/1.1" 200 2
{   'context': 'buildbot/test:position/static_checks_2',
    'description': 'Build done.',
    'state': 'failure',
    'target_url': 'http://kax-desktop.slamcore.local:8010/#builders/105/builds/38'}
127.0.0.1 - - [12/Apr/2023 17:21:31] "POST /mockgithub/repos/slamcore/position/statuses/3dfc382d361b2609ca157ee9950a88c76427c1b6 HTTP/1.1" 200 2
```

Without this change the messages were only emitted if I set

```python
    builders=["test:position/static_checks_2'"]))
```
